### PR TITLE
Possibility to choose the packager class

### DIFF
--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -93,7 +93,8 @@ module Jammit
   # Keep a global (thread-local) reference to a @Jammit::Packager@, to avoid
   # recomputing asset lists unnecessarily.
   def self.packager
-    Thread.current[:jammit_packager] ||= Packager.new
+    packager_class = @configuration[:packager_class].nil? ? Packager : @configuration[:packager_class].constantize
+    Thread.current[:jammit_packager] ||= packager_class.new
   end
 
   # Generate the base filename for a version of a given package.

--- a/test/config/assets-packager.yml
+++ b/test/config/assets-packager.yml
@@ -1,0 +1,30 @@
+embed_assets: on
+
+javascripts:
+  js_test: &js_test
+    - fixtures/src/*.js
+  js_test_with_templates:
+    - fixtures/src/*.js
+    - fixtures/src/*.jst
+  js_test_nested:
+    - *js_test
+    - fixtures/src/nested/*.js
+  jst_test: &jst_test
+    - fixtures/src/*.jst
+  jst_test_diff_ext: &jst_test_diff_ext
+    - fixtures/src/*.html.mustache
+  jst_test_nested:
+    - *jst_test
+    - fixtures/src/nested/**/*.jst
+  jst_test_diff_ext_and_nested:
+    - *jst_test_diff_ext
+    - fixtures/src/nested/**/*.html.mustache
+
+stylesheets:
+  css_test: &css_test
+    - fixtures/src/*.css
+  css_test_nested:
+    - *css_test
+    - fixtures/src/nested/*.css
+
+packager_class: TestPackager

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -1,5 +1,8 @@
 require 'test_helper'
 
+class TestPackager < Jammit::Packager
+end
+
 class BrokenConfigurationTest < Test::Unit::TestCase
 
   def setup
@@ -75,6 +78,11 @@ class BrokenConfigurationTest < Test::Unit::TestCase
   def test_jst_compilation
     packed = @compressor.compile_jst(glob('test/fixtures/src/*.jst'))
     assert packed == File.read('test/fixtures/jammed/jst_test.js')
+  end
+
+  def test_packager
+    Jammit.load_configuration('test/config/assets-packager.yml')
+    assert_instance_of TestPackager, Jammit.packager
   end
 
 end


### PR DESCRIPTION
Now the user is able to create a custom packager class:

```
class TestPackager < Jammit::Packager
end
```

and point Jammit to use this class by adding a "packager_class" option to assets.yml:

```
packager_class: TestPackager
```
