### PR TITLE
Allow periods in extensions under Rails 3 (issue #69)

### DIFF
--- a/rails/routes.rb
+++ b/rails/routes.rb
@@ -2,6 +2,9 @@ if defined?(Rails::Application)
   # Rails3 routes
   Rails.application.routes.draw do
     match "/#{Jammit.package_path}/:package.:extension",
-      :to => 'jammit#package', :as => :jammit
+      :to => 'jammit#package', :as => :jammit, :constraints => {
+        # A hack to allow extension to include "."
+        :extension => /.+/
+      }
   end
 end


### PR DESCRIPTION
Ported the Rails 2 route hack to Rails 3. Fixes the issues I was having on my Rails 3 app.

Issue #69
http://github.com/documentcloud/jammit/issues#issue/69
