### PR TITLE
Assets should not be packaged in test env

### DIFF
--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -121,7 +121,7 @@ module Jammit
 
   # Turn asset packaging on or off, depending on configuration and environment.
   def self.set_package_assets(value)
-    package_env     = !defined?(Rails) || !Rails.env.development?
+    package_env     = !defined?(Rails) || (!Rails.env.development? && !Rails.env.test?)
     @package_assets = value == true || value.nil? ? package_env :
                       value == 'always'           ? true : false
   end

--- a/lib/jammit/controller.rb
+++ b/lib/jammit/controller.rb
@@ -87,7 +87,7 @@ end
 # Make the Jammit::Controller available to Rails as a top-level controller.
 ::JammitController = Jammit::Controller
 
-if defined?(Rails) && Rails.env.development?
+if defined?(Rails) && (Rails.env.development? || Rails.env.test?)
   ActionController::Base.class_eval do
     append_before_filter { Jammit.reload! }
   end


### PR DESCRIPTION
When running cucumber scripts that use capybara and selenium, I ran into an issue where it kept trying to use the packaged file that had been created when I deployed instead of the new application.js I had edited.

It doesn't seem to make sense to package the assets in the test environment so this patch should fix this (or at least point to the starting location).
