### PR TITLE
Maintain position of JST templates

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -64,10 +64,14 @@ module Jammit
     # Concatenate together a list of JavaScript paths, and pass them through the
     # YUI Compressor (with munging enabled). JST can optionally be included.
     def compress_js(paths)
-      if (jst_paths = paths.grep(Jammit.template_extension_matcher)).empty?
+      jst_paths = paths.grep(Jammit.template_extension_matcher)
+      if jst_paths.empty?
         js = concatenate(paths)
       else
-        js = concatenate(paths - jst_paths) + compile_jst(jst_paths)
+        fjst_idx = paths.index(jst_paths.first)
+        js_paths_a = (paths - jst_paths.drop(1)).shift(fjst_idx)
+        js_paths_b = (paths - jst_paths.drop(1)).drop(fjst_idx+1)
+        js = concatenate(js_paths_a) + compile_jst(jst_paths) + concatenate(js_paths_b)
       end
       Jammit.compress_assets ? @js_compressor.compress(js) : js
     end

--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -142,12 +142,11 @@ module Jammit
         packages[name]         = {}
         paths                  = globs.flatten.uniq.map {|glob| glob_files(glob) }.flatten.uniq
         packages[name][:paths] = paths
-        if !paths.grep(Jammit.template_extension_matcher).empty?
-          packages[name][:urls] = paths.grep(JS_EXTENSION).map {|path| path.sub(PATH_TO_URL, '') }
-          packages[name][:urls] += [Jammit.asset_url(name, Jammit.template_extension)]
-        else
-          packages[name][:urls] = paths.map {|path| path.sub(PATH_TO_URL, '') }
-        end
+        jst_paths              = paths.grep(Jammit.template_extension_matcher)
+        fjst_idx               = paths.index(jst_paths.shift)
+        
+        packages[name][:urls]           = (paths - jst_paths).map {|path| path.sub(PATH_TO_URL, '') }
+        packages[name][:urls][fjst_idx] = Jammit.asset_url(name, Jammit.template_extension) if fjst_idx
       end
       packages
     end


### PR DESCRIPTION
Ran into an issue where I needed some vendored libraries (like underscore and jQuery) loaded before my templates, but my application specific js (e.g. common.js, core.js) loaded after the templates.

Updated to work with compressor.
