### PR TITLE
Fixed encoding problems on ruby 1.9.2

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -97,12 +97,12 @@ module Jammit
       paths       = paths.grep(Jammit.template_extension_matcher).sort
       base_path   = find_base_path(paths)
       compiled    = paths.map do |path|
-        contents  = File.open(path, 'r:binary') {|f| f.read }
+        contents  = read_binary_file(path)
         contents  = contents.gsub(/\n/, '').gsub("'", '\\\\\'')
         name      = template_name(path, base_path)
         "#{namespace}['#{name}'] = #{Jammit.template_function}('#{contents}');"
       end
-      compiler = Jammit.include_jst_script ? File.read(DEFAULT_JST_SCRIPT) : '';
+      compiler = Jammit.include_jst_script ? read_binary_file(DEFAULT_JST_SCRIPT) : '';
       setup_namespace = "#{namespace} = #{namespace} || {};"
       [JST_START, setup_namespace, compiler, compiled, JST_END].flatten.join("\n")
     end
@@ -137,7 +137,7 @@ module Jammit
     # at it.
     def concatenate_and_tag_assets(paths, variant=nil)
       stylesheets = [paths].flatten.map do |css_path|
-        contents = File.open(css_path, 'r:binary') {|f| f.read }
+        contents = read_binary_file(css_path)
         contents.gsub(EMBED_DETECTOR) do |url|
           ipath, cpath = Pathname.new($1), Pathname.new(File.expand_path(css_path))
           is_url = URI.parse($1).absolute?
@@ -228,7 +228,7 @@ module Jammit
     # Return the Base64-encoded contents of an asset on a single line.
     def encoded_contents(asset_path)
       return @asset_contents[asset_path] if @asset_contents[asset_path]
-      data = File.open(asset_path, 'rb') {|f| f.read }
+      data = read_binary_file(asset_path)
       @asset_contents[asset_path] = Base64.encode64(data).gsub(/\n/, '')
     end
 
@@ -239,9 +239,12 @@ module Jammit
 
     # Concatenate together a list of asset files.
     def concatenate(paths)
-      [paths].flatten.map {|p| File.read(p) }.join("\n")
+      [paths].flatten.map {|p| read_binary_file(p) }.join("\n")
     end
-
+    
+    def read_binary_file(path)
+      File.open(path, 'r:binary') {|f| f.read }
+    end
   end
 
 end


### PR DESCRIPTION
I've fixed problem when some files were treated like binary where some not. Now all files should be read with function @read_binary_file@ which reads them as binary.
I wanted to create tests, but I've figured out that I would need to regenerate compressed fixtures if i change something. So failing test would be something like this:

```
@compressor.compress_js 'test/fixtures/utf8_characters.js', 'test/fixtures/*.jst'
```

This would throw exception before this fix.
