### PR TITLE
Fix template name generation when unsafe regex characters are in base_path

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -128,7 +128,7 @@ module Jammit
     # the namespaced prefix. Otherwise, simply use the filename.
     def template_name(path, base_path)
       return File.basename(path, ".#{Jammit.template_extension}") unless base_path
-      path.gsub(/\A#{base_path}\/(.*)\.#{Jammit.template_extension}\Z/, '\1')
+      path.gsub(/\A#{Regexp.escape(base_path)}\/(.*)\.#{Jammit.template_extension}\Z/, '\1')
     end
 
     # In order to support embedded assets from relative paths, we need to


### PR DESCRIPTION
Templates in paths like the following

/Users/dave(old)/Sites/app/megan.jst

/Users/dave(old)/Sites/app/fox.jst

are not shortened to the templates `megan` and `fox`, but are rather added to the JST object with their full paths.

`Regexp.escape(base_path)` before doing the gsub fixes this problem. 
