### PR TITLE
Better mtime timestamps on generated asset package files

### DIFF
--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -54,7 +54,12 @@ module Jammit
     # Caches a single prebuilt asset package and gzips it at the highest
     # compression level. Ensures that the modification time of both both
     # variants is identical, for web server caching modules, as well as MHTML.
-    def cache(package, extension, contents, output_dir, suffix=nil, mtime=Time.now)
+    def cache(package, extension, contents, output_dir, suffix=nil, mtime=nil)
+      if mtime.nil?
+        mtimes = package_for(package, extension.to_sym)[:paths].map {|src| File.mtime(src) }
+        mtimes.push File.mtime(Jammit.config_path)
+        mtime = mtimes.max
+      end
       FileUtils.mkdir_p(output_dir) unless File.exists?(output_dir)
       raise OutputNotWritable, "Jammit doesn't have permission to write to \"#{output_dir}\"" unless File.writable?(output_dir)
       files = []


### PR DESCRIPTION
Jammit's packager always sets the mtime of generated asset packages (the .css and .js files in public/assets) to Time.now.

Jammit could instead set the mtime to equal the mtime of the newest source file in the package, or if newer, the mtime of the Jammit configuration file.

When Jammit is run next time for a package, it can still detect if any of the source files or the configuration file has changed because it will still have a newer mtime than the generated asset package.

This will help greatly in environments where every deploy is sandboxed to its own directory, so there is no previous generated asset package files in public/assets.

This could be configurable via a switch if necessary.

Thanks!
