### PR TITLE
Fixed compile_jst function to support crlf on windows (thanx to jashkenas)

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -98,7 +98,7 @@ module Jammit
       base_path   = find_base_path(paths)
       compiled    = paths.map do |path|
         contents  = read_binary_file(path)
-        contents  = contents.gsub(/\n/, '').gsub("'", '\\\\\'')
+        contents  = contents.gsub(/\r?\n/, '').gsub("'", '\\\\\'')
         name      = template_name(path, base_path)
         "#{namespace}['#{name}'] = #{Jammit.template_function}('#{contents}');"
       end


### PR DESCRIPTION
The compile_jst function now replaces crlf in (\r\n) in JST templates. This fixes an issue where the function would render line breaks within the template string on windows (resulting in invalid JS).
