### PR TITLE
support for haml.js as jst template language

### DIFF
--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -50,7 +50,8 @@ module Jammit
                 :embed_assets, :package_assets, :compress_assets, :gzip_assets,
                 :package_path, :mhtml_enabled, :include_jst_script, :config_path,
                 :javascript_compressor, :compressor_options, :css_compressor_options,
-                :template_extension, :template_extension_matcher, :allow_debugging
+                :template_extension, :template_extension_matcher, :allow_debugging, 
+                :template_strip_newlines
   end
 
   # The minimal required configuration.
@@ -74,6 +75,7 @@ module Jammit
     @mhtml_enabled          = @embed_assets && @embed_assets != "datauri"
     @compressor_options     = symbolize_keys(conf[:compressor_options] || {})
     @css_compressor_options = symbolize_keys(conf[:css_compressor_options] || {})
+    @template_strip_newlines= !(conf[:template_strip_newlines] == false)
     set_javascript_compressor(conf[:javascript_compressor])
     set_package_assets(conf[:package_assets])
     set_template_function(conf[:template_function])

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -98,7 +98,8 @@ module Jammit
       base_path   = find_base_path(paths)
       compiled    = paths.map do |path|
         contents  = read_binary_file(path)
-        contents  = contents.gsub(/\n/, '').gsub("'", '\\\\\'')
+        newline   = Jammit.template_strip_newlines ? "" : "\\n"
+        contents  = contents.gsub(/\n/, newline).gsub("'", '\\\\\'')
         name      = template_name(path, base_path)
         "#{namespace}['#{name}'] = #{Jammit.template_function}('#{contents}');"
       end

--- a/test/config/assets-jst-newlines.yml
+++ b/test/config/assets-jst-newlines.yml
@@ -1,0 +1,1 @@
+template_strip_newlines: off

--- a/test/fixtures/jammed/jst_test_newlines.js
+++ b/test/fixtures/jammed/jst_test_newlines.js
@@ -1,0 +1,6 @@
+(function(){
+window.JST = window.JST || {};
+var template = function(str){var fn = new Function('obj', 'var p=[],print=function(){p.push.apply(p,arguments);};with(obj){p.push(\''+str.replace(/[\r\t\n]/g, " ").replace(/'(?=[^%]*%>)/g,"\t").split("'").join("\\'").split("\t").join("'").replace(/<%=(.+?)%>/g,"',$1,'").split("<%").join("');").split("%>").join("p.push('")+"');}return p.join('');"); return fn;};
+window.JST['template1'] = template('<a href="<%= to_somewhere %>"><%= saying_something %></a>');
+window.JST['template2'] = template('<% _([1,2,3]).each(function(num) { %>\n  <li class="number">\n    <%= num %>\n  </li>\n<% }) %>');
+})();

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -62,4 +62,11 @@ class BrokenConfigurationTest < Test::Unit::TestCase
     assert packed == File.read('test/fixtures/jammed/jst_test.js')
   end
 
+  def test_jst_compilation_with_newlines
+    Jammit.load_configuration('test/config/assets-jst-newlines.yml')
+    assert !Jammit.template_strip_newlines
+    packed = @compressor.compile_jst(glob('test/fixtures/src/*.jst'))
+    assert packed == File.read('test/fixtures/jammed/jst_test_newlines.js')
+  end
+
 end


### PR DESCRIPTION
By allowing newline characters in the template, one is able to use haml.js as a templating language.

solves 127
https://github.com/documentcloud/jammit/issues#issue/127
