### PR TITLE
Clarify instructions for routes setup in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,11 +141,9 @@
         <tt>config.gem "jammit"</tt>
       </li>
       <li>
-        If you're using <b>Rails 2</b>, edit <b>config/routes.rb</b> to give Jammit a route
-        ( <b>/assets</b> by default) for dynamic asset packaging and caching.
-        In <b>Rails 3</b>, this route is loaded automatically.
-        <br /><br />
-
+        <p>If you're using <b>Rails 3</b> you're done &mdash; Jammit routes are loaded automatically into your app.</p>
+        <p>If you're using <b>Rails 2</b>, edit <b>config/routes.rb</b> to give Jammit a route
+        ( <b>/assets</b> by default) for dynamic asset packaging and caching.</p>
 <pre>
 ActionController::Routing::Routes.draw do |map|
   ...


### PR DESCRIPTION
After https://github.com/documentcloud/jammit/issues/closed#issue/150 I thought it would be good to clarify Step 3 of the instructions to be more explicit that on Rails 3, no editing of `config/routes.rb` is necessary. This is my attempt at doing so. Hope you approve!

Cheers,
Vlad
