### PR TITLE
Soft dependencies on closure and uglify and yui as default.

### DIFF
--- a/jammit.gemspec
+++ b/jammit.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
                          '--all'
 
   s.add_dependency 'yui-compressor',    ['>= 0.9.3']
-  s.add_dependency 'closure-compiler',  ['>= 0.1.0']
-  s.add_dependency 'uglifier',          ['>= 0.4.0']
+  #s.add_dependency 'closure-compiler',  ['>= 0.1.0']
+  #s.add_dependency 'uglifier',          ['>= 0.4.0']
 
   s.files = Dir['lib/**/*', 'bin/*', 'rails/*', 'jammit.gemspec', 'LICENSE', 'README']
 end

--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -51,11 +51,13 @@ module Jammit
                 :package_path, :mhtml_enabled, :include_jst_script, :config_path,
                 :javascript_compressor, :compressor_options, :css_compressor_options,
                 :template_extension, :template_extension_matcher, :allow_debugging
+    attr_accessor :loaded_compressors
   end
 
   # The minimal required configuration.
   @configuration = {}
   @package_path  = DEFAULT_PACKAGE_PATH
+  @loaded_compressors = AVAILABLE_COMPRESSORS
 
   # Load the complete asset configuration from the specified @config_path@.
   # If we're loading softly, don't let missing configuration error out.
@@ -134,7 +136,7 @@ module Jammit
   # Ensure that the JavaScript compressor is a valid choice.
   def self.set_javascript_compressor(value)
     value = value && value.to_sym
-    @javascript_compressor = AVAILABLE_COMPRESSORS.include?(value) ? value : DEFAULT_COMPRESSOR
+    @javascript_compressor = loaded_compressors.include?(value) ? value : DEFAULT_COMPRESSOR
   end
 
   # Turn asset packaging on or off, depending on configuration and environment.

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -43,9 +43,10 @@ module Jammit
 
     COMPRESSORS = {
       :yui      => YUI::JavaScriptCompressor,
-      :closure  => Closure::Compiler,
-      :uglifier => Jammit::Uglifier
     }
+    
+    COMPRESSORS[:closure] = Closure::Compiler if Jammit.loaded_compressors.include? :closure
+    COMPRESSORS[:uglifier] = Jammit::Uglifier  if Jammit.loaded_compressors.include? :uglifier
 
     DEFAULT_OPTIONS = {
       :yui      => {:munge => true},

--- a/lib/jammit/dependencies.rb
+++ b/lib/jammit/dependencies.rb
@@ -8,15 +8,31 @@ require 'pathname'
 require 'fileutils'
 
 # Gem Dependencies:
+available_dependencies = []
+
+# Include YUI as the default
 require 'yui/compressor'
-require 'closure-compiler'
-require 'uglifier'
+
+begin
+  require 'closure-compiler'
+  available_dependencies << :closure
+rescue LoadError
+  Jammit.loaded_compressors.delete :closure
+  puts "Closure is unavailable."
+end
+begin
+  require 'uglifier'
+  available_dependencies << :uglifier
+rescue LoadError
+  Jammit.loaded_compressors.delete :uglifier
+  puts "Uglifier is unavailable."
+end
 
 # Load initial configuration before the rest of Jammit.
 Jammit.load_configuration(Jammit::DEFAULT_CONFIG_PATH, true) if defined?(Rails)
 
 # Jammit Core:
-require 'jammit/uglifier'
+require 'jammit/uglifier' if Jammit.loaded_compressors.include?( :uglifier )
 require 'jammit/compressor'
 require 'jammit/packager'
 


### PR DESCRIPTION
Based on issue https://github.com/documentcloud/jammit/issues/closed/#issue/123/comment/916842

This provides a more flexible approach. You can chose your compressor and not install any other. 
