### PR TITLE
Fix failing test due to incorrect format of fixture file

### DIFF
--- a/test/fixtures/jammed/js_test-uglifier.js
+++ b/test/fixtures/jammed/js_test-uglifier.js
@@ -1,1 +1,1 @@
-var myself={sayHi:function(a){console.log("hello, "+a)}},mandelay={name:function(){return this.constructor.prototype}};myself.sayHi(mandelay.name())
+var myself={sayHi:function(a){console.log("hello, "+a)}};var mandelay={name:function(){return this.constructor.prototype}};myself.sayHi(mandelay.name());


### PR DESCRIPTION
Hi,

I was getting a failing spec for UglifierText#test_javascript_compression . I believe the problem was due to the fixture file and adjusted it so the tests would pass.

Adjust `js_test-uglifier.js` fixture file to match actual output of `compress_js`

Thanks and keep up the good work!
