### PR TITLE
Set the mtime of pre-cached files to the mtime of the newest file from the corresponding package

### DIFF
--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -37,13 +37,13 @@ module Jammit
     # changed since their last package build.
     def precache_all(output_dir=nil, base_url=nil)
       output_dir ||= File.join(PUBLIC_ROOT, Jammit.package_path)
-      cacheable(:js, output_dir).each  {|p| cache(p, 'js',  pack_javascripts(p), output_dir) }
+      cacheable(:js, output_dir).each  {|p| cache(p, 'js',  pack_javascripts(p), output_dir, nil, newest_mtime(p, :js)) }
       cacheable(:css, output_dir).each do |p|
-        cache(p, 'css', pack_stylesheets(p), output_dir)
+        mtime = newest_mtime(p, :css)
+        cache(p, 'css', pack_stylesheets(p), output_dir, nil, mtime)
         if Jammit.embed_assets
-          cache(p, 'css', pack_stylesheets(p, :datauri), output_dir, :datauri)
+          cache(p, 'css', pack_stylesheets(p, :datauri), output_dir, :datauri, mtime)
           if Jammit.mhtml_enabled && base_url
-            mtime = Time.now
             asset_url = "#{base_url}#{Jammit.asset_url(p, :css, :mhtml, mtime)}"
             cache(p, 'css', pack_stylesheets(p, :mhtml, asset_url), output_dir, :mhtml, mtime)
           end
@@ -70,6 +70,11 @@ module Jammit
     # Get the list of individual assets for a package.
     def individual_urls(package, extension)
       package_for(package, extension)[:urls]
+    end
+
+    # Return the modification time of the newest file in the package
+    def newest_mtime(package, extension)
+      package_for(package, extension)[:paths].map { |path| File.mtime(path) }.max
     end
 
     # Return the compressed contents of a stylesheet package.


### PR DESCRIPTION
Disclaimer: As this is my first pull request and even one of the very few times I've even pushed to GitHub, please let me know if I'm doing something in a wrong way.

I've made a small change to `Jammit::Packager#precache_all`, which should set the mtime of the resulting cached package file to the mtime of the newest file in the package which is being processed. This change should affect only pre-caching via the `jammit` command (or any code which uses `Jammit.package!`).

I think that this way we will preserve correct invalidation but will minimize occasions when the pre-cached content is being cache-invalidated in browsers because of, say, pre-caching during deployment. This would be advantageous in case your source files have correct mtimes after deployment (which is the case when you `svn export`, for example).

All comments are welcome.
