### PR TITLE
Extract compile_single_jst from compile_jst

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -99,14 +99,18 @@ module Jammit
       paths       = paths.grep(Jammit.template_extension_matcher).sort
       base_path   = find_base_path(paths)
       compiled    = paths.map do |path|
-        contents  = read_binary_file(path)
-        contents  = contents.gsub(/\r?\n/, "\\n").gsub("'", '\\\\\'')
         name      = template_name(path, base_path)
-        "#{namespace}['#{name}'] = #{Jammit.template_function}('#{contents}');"
+        "#{namespace}['#{name}'] = #{compile_single_jst(path)};"
       end
       compiler = Jammit.include_jst_script ? read_binary_file(DEFAULT_JST_SCRIPT) : '';
       setup_namespace = "#{namespace} = #{namespace} || {};"
       [JST_START, setup_namespace, compiler, compiled, JST_END].flatten.join("\n")
+    end
+
+    def compile_single_jst(path)
+      contents  = read_binary_file(path)
+      contents  = contents.gsub(/\r?\n/, "\\n").gsub("'", '\\\\\'')
+      "#{Jammit.template_function}('#{contents}')"
     end
 
 


### PR DESCRIPTION
Extract compile_single_jst from compile_jst to make for easier monkey patching replacement of compilation logic. Pretty simple quick change. I just wanted to wrap some pre/post processing onto the jst compilation and this was the most lightweight way to do so.
