### PR TITLE
Updated glob sorting to sort files in parent directories ahead of files in sub-directories.

### DIFF
--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -103,9 +103,24 @@ module Jammit
     # Print a warning if no files were found that match the glob.
     def glob_files(glob)
       absolute = Pathname.new(glob).absolute?
-      paths = Dir[absolute ? glob : File.join(ASSET_ROOT, glob)].sort
+      paths = Dir[absolute ? glob : File.join(ASSET_ROOT, glob)].sort(&method(:glob_comparator))
       Jammit.warn("No assets match '#{glob}'") if paths.empty?
       paths
+    end
+
+    # Compares two paths, sorting files in parent directories before
+    # files in their subdirectories.
+    #  a/a.js
+    #  a/b.js
+    #  a/a/a.js
+    def glob_comparator(path1, path2)
+      dir1 = File.dirname(path1)
+      dir2 = File.dirname(path2)
+
+      return path1 <=> path2 if dir1 == dir2
+      return 1 if dir1.start_with?(dir2)
+      return -1 if dir2.start_with?(dir1)
+      dir1 <=> dir2
     end
     
     # Get the latest mtime of a list of files (plus the config path).

--- a/test/config/assets.yml
+++ b/test/config/assets.yml
@@ -9,6 +9,8 @@ javascripts:
   js_test_nested:
     - *js_test
     - fixtures/src/nested/*.js
+  js_test_nested2:
+    - fixtures/src/**/*.js
   jst_test: &jst_test
     - fixtures/src/*.jst
   jst_test_nested:

--- a/test/unit/test_packager.rb
+++ b/test/unit/test_packager.rb
@@ -26,6 +26,8 @@ class PackagerTest < Test::Unit::TestCase
     assert urls == ['/fixtures/src/test1.css', '/fixtures/src/test2.css', '/fixtures/src/test_fonts.css', '/fixtures/src/nested/nested1.css', '/fixtures/src/nested/nested2.css']
     urls = Jammit.packager.individual_urls(:js_test_nested, :js)
     assert urls == ['/fixtures/src/test1.js', '/fixtures/src/test2.js', '/fixtures/src/nested/nested1.js', '/fixtures/src/nested/nested2.js']
+    urls = Jammit.packager.individual_urls(:js_test_nested2, :js)
+    assert urls == ['/fixtures/src/test1.js', '/fixtures/src/test2.js', '/fixtures/src/nested/nested1.js', '/fixtures/src/nested/nested2.js']
     urls = Jammit.packager.individual_urls(:jst_test_nested, :js)
     assert urls == ['/assets/jst_test_nested.jst']
   end


### PR DESCRIPTION
Previously Dir[].sort was called, which would result in the following sort order:
/a/a/a.js
/a/b.js

The patch changes the sort order to the following:
/a/b.js
/a/a/a.js

My motivation for the patch was having the following structure:
views/views.js
views/model/action.js

view.js defined a views namespace. action.js used it. Of course there are other ways to fix this, but the updated sort order seemed to make sense anyway.

I added one test to test the behaviour.
