### PR TITLE
Prefixing Rails with :: and checking that ::Rails responds_to? env, root, etc

### DIFF
--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -10,7 +10,7 @@ module Jammit
 
   ASSET_ROOT            = File.expand_path((defined?(::Rails) && ::Rails.respond_to?(:root) && ::Rails.root.to_s.length > 0) ? ::Rails.root : ENV['RAILS_ROOT'] || ".") unless defined?(ASSET_ROOT)
 
-  PUBLIC_ROOT           = (defined?(::Rails) && ::Rails.public_path.to_s.length > 0) ? ::Rails.public_path : File.join(ASSET_ROOT, 'public') unless defined?(PUBLIC_ROOT)
+  PUBLIC_ROOT           = (defined?(::Rails) && ::Rails.respond_to?(:public_path) && ::Rails.public_path.to_s.length > 0) ? ::Rails.public_path : File.join(ASSET_ROOT, 'public') unless defined?(PUBLIC_ROOT)
 
   DEFAULT_CONFIG_PATH   = File.join(ASSET_ROOT, 'config', 'assets.yml')
 

--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -8,7 +8,7 @@ module Jammit
 
   ROOT                  = File.expand_path(File.dirname(__FILE__) + '/..')
 
-  ASSET_ROOT            = File.expand_path((defined?(::Rails) && ::Rails.root.to_s.length > 0) ? ::Rails.root : ENV['RAILS_ROOT'] || ".") unless defined?(ASSET_ROOT)
+  ASSET_ROOT            = File.expand_path((defined?(::Rails) && ::Rails.respond_to?(:root) && ::Rails.root.to_s.length > 0) ? ::Rails.root : ENV['RAILS_ROOT'] || ".") unless defined?(ASSET_ROOT)
 
   PUBLIC_ROOT           = (defined?(::Rails) && ::Rails.public_path.to_s.length > 0) ? ::Rails.public_path : File.join(ASSET_ROOT, 'public') unless defined?(PUBLIC_ROOT)
 

--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -69,7 +69,7 @@ module Jammit
     conf = YAML.load(ERB.new(File.read(config_path)).result)
 
     # Optionally overwrite configuration based on the environment.
-    rails_env = (defined?(::Rails) && ::Rails.respond_to(:env)) ? ::Rails.env : ENV['RAILS_ENV']
+    rails_env = (defined?(::Rails) && ::Rails.respond_to?(:env)) ? ::Rails.env : ENV['RAILS_ENV']
     conf.merge! conf.delete rails_env if conf.has_key? rails_env
 
     @config_path            = config_path

--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -8,9 +8,9 @@ module Jammit
 
   ROOT                  = File.expand_path(File.dirname(__FILE__) + '/..')
 
-  ASSET_ROOT            = File.expand_path((defined?(Rails) && Rails.root.to_s.length > 0) ? Rails.root : ENV['RAILS_ROOT'] || ".") unless defined?(ASSET_ROOT)
+  ASSET_ROOT            = File.expand_path((defined?(::Rails) && ::Rails.root.to_s.length > 0) ? ::Rails.root : ENV['RAILS_ROOT'] || ".") unless defined?(ASSET_ROOT)
 
-  PUBLIC_ROOT           = (defined?(Rails) && Rails.public_path.to_s.length > 0) ? Rails.public_path : File.join(ASSET_ROOT, 'public') unless defined?(PUBLIC_ROOT)
+  PUBLIC_ROOT           = (defined?(::Rails) && ::Rails.public_path.to_s.length > 0) ? ::Rails.public_path : File.join(ASSET_ROOT, 'public') unless defined?(PUBLIC_ROOT)
 
   DEFAULT_CONFIG_PATH   = File.join(ASSET_ROOT, 'config', 'assets.yml')
 
@@ -69,7 +69,7 @@ module Jammit
     conf = YAML.load(ERB.new(File.read(config_path)).result)
 
     # Optionally overwrite configuration based on the environment.
-    rails_env = defined?(Rails) ? Rails.env : ENV['RAILS_ENV']
+    rails_env = defined?(::Rails) ? ::Rails.env : ENV['RAILS_ENV']
     conf.merge! conf.delete rails_env if conf.has_key? rails_env
 
     @config_path            = config_path
@@ -142,7 +142,7 @@ module Jammit
 
   # Turn asset packaging on or off, depending on configuration and environment.
   def self.set_package_assets(value)
-    package_env     = !defined?(Rails) || (!Rails.env.development? && !Rails.env.test?)
+    package_env     = !defined?(::Rails) || (!::Rails.env.development? && !::Rails.env.test?)
     @package_assets = value == true || value.nil? ? package_env :
                       value == 'always'           ? true : false
   end

--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -69,7 +69,7 @@ module Jammit
     conf = YAML.load(ERB.new(File.read(config_path)).result)
 
     # Optionally overwrite configuration based on the environment.
-    rails_env = defined?(::Rails) ? ::Rails.env : ENV['RAILS_ENV']
+    rails_env = (defined?(::Rails) && ::Rails.respond_to(:env)) ? ::Rails.env : ENV['RAILS_ENV']
     conf.merge! conf.delete rails_env if conf.has_key? rails_env
 
     @config_path            = config_path
@@ -142,7 +142,7 @@ module Jammit
 
   # Turn asset packaging on or off, depending on configuration and environment.
   def self.set_package_assets(value)
-    package_env     = !defined?(::Rails) || (!::Rails.env.development? && !::Rails.env.test?)
+    package_env     = !defined?(::Rails) || !::Rails.respond_to?(:env) || (!::Rails.env.development? && !::Rails.env.test?)
     @package_assets = value == true || value.nil? ? package_env :
                       value == 'always'           ? true : false
   end

--- a/lib/jammit/controller.rb
+++ b/lib/jammit/controller.rb
@@ -90,7 +90,7 @@ end
 # Make the Jammit::Controller available to Rails as a top-level controller.
 ::JammitController = Jammit::Controller
 
-if defined?(::Rails) && ::Rails.env.development?
+if defined?(::Rails) && ::Rails.respond_to?(:env) && ::Rails.env.development?
   ActionController::Base.class_eval do
     append_before_filter { Jammit.reload! }
   end

--- a/lib/jammit/controller.rb
+++ b/lib/jammit/controller.rb
@@ -90,7 +90,7 @@ end
 # Make the Jammit::Controller available to Rails as a top-level controller.
 ::JammitController = Jammit::Controller
 
-if defined?(Rails) && Rails.env.development?
+if defined?(::Rails) && ::Rails.env.development?
   ActionController::Base.class_eval do
     append_before_filter { Jammit.reload! }
   end

--- a/rails/routes.rb
+++ b/rails/routes.rb
@@ -1,6 +1,6 @@
-if defined?(Rails::Application)
+if defined?(::Rails::Application)
   # Rails3 routes
-  Rails.application.routes.draw do
+  ::Rails.application.routes.draw do
     match "/#{Jammit.package_path}/:package.:extension",
       :to => 'jammit#package', :as => :jammit, :constraints => {
         # A hack to allow extension to include "."


### PR DESCRIPTION
I am using Jammit for asset packaging and in order to get the JST templates compiled, I am forcing Jammit to package in the jasmine_config.rb file.  For some reason (probably having to do with rspec-rails updates), the Rails module doesn't respond to root, env, public_path etc anymore.  

I have made changes to jammit.rb and controller.rb to prefix all Rails with :: and check that they respond_to? root, env, public_path etc.
