### PR TITLE
Add ability to use eco templates

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -100,9 +100,13 @@ module Jammit
       base_path   = find_base_path(paths)
       compiled    = paths.map do |path|
         contents  = read_binary_file(path)
-        contents  = contents.gsub(/\r?\n/, "\\n").gsub("'", '\\\\\'')
         name      = template_name(path, base_path)
-        "#{namespace}['#{name}'] = #{Jammit.template_function}('#{contents}');"
+        if Jammit.template_extension == 'eco'
+          "#{namespace}['#{name}'] = #{Eco.compile(contents)};"
+        else
+          contents.gsub(/\r?\n/, "\\n").gsub("'", '\\\\\'')
+          "#{namespace}['#{name}'] = #{Jammit.template_function}('#{contents}');"
+        end
       end
       compiler = Jammit.include_jst_script ? read_binary_file(DEFAULT_JST_SCRIPT) : '';
       setup_namespace = "#{namespace} = #{namespace} || {};"


### PR DESCRIPTION
Purposely did not add the ruby-eco gem dependency
to the gemspec because I figured it would be best
to only rely on it if, in assets.yml, you do: 
template_function: off
template_extension: eco

This is a rough whack at getting it to work, I didn't
add any tests or anything.  Is this something
you want to do?
