### PR TITLE
Read JS files as UTF-8. Fixes #198

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -246,7 +246,7 @@ module Jammit
 
     # `File.read`, but in "binary" mode.
     def read_binary_file(path)
-      File.open(path, 'rb') {|f| f.read }
+      File.open(path, 'rb:UTF-8') {|f| f.read }
     end
   end
 


### PR DESCRIPTION
Read JS files as UTF-8. Fixes #198
