### PR TITLE
Avoid method missing when using include_stylesheets in mailer templates

### DIFF
--- a/lib/jammit/helper.rb
+++ b/lib/jammit/helper.rb
@@ -43,7 +43,7 @@ module Jammit
     private
 
     def should_package?
-      Jammit.package_assets && !(Jammit.allow_debugging && params[:debug_assets])
+      Jammit.package_assets && !(Jammit.allow_debugging && respond_to?(:params) && params[:debug_assets])
     end
 
     def html_safe(string)


### PR DESCRIPTION
Using `include_stylesheets` in a mailer view raises an exception because ActionMailer::Base doesn't respond to `params` but `should_package?` expects it to. This adds a check to make sure the class responds to params.

Note: In general, including stylesheets in a mailer view isn't a good idea, but thanks to the roadie gem which automatically inlines styles, this makes more sense.
