### PR TITLE
fix for using 'sass' css compressor

### DIFF
--- a/lib/jammit/sass_compressor.rb
+++ b/lib/jammit/sass_compressor.rb
@@ -10,7 +10,7 @@ class Jammit::SassCompressor
   # Compresses +css+ using sass' CSS parser, and returns the
   # compressed css.
   def compress(css)
-    root_node = ::Sass::SCSS::CssParser.new(css).parse
+    root_node = ::Sass::SCSS::CssParser.new(css, 'jammit-combined-input').parse
     root_node.options = {:style => :compressed}
     root_node.render.strip
   end


### PR DESCRIPTION
running jammit using the 'sass' css compressor would
fail because this method expects at least 2 arguments

see: http://sass-lang.com/docs/yardoc/Sass/SCSS/Parser.html#initialize-instance_method

since, at this point, it is just the combined
input for all of the files in a bundle, there is no
real filename i just called it 'jammit-combined-input'
