### PR TITLE
Adding Jammit::Packager#includes? to detect existence of compiled assets.

### DIFF
--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -70,8 +70,9 @@ module Jammit
       package_for(package, extension)[:urls]
     end
 
-    def asset_defined?(package, extension)
-      !!package_for(package, extension)
+    # Determines the existence of a packaged asset in the assets.yml file.
+    def includes?(package, extension)
+      !!package_for(package.to_sym, extension.to_sym)
     rescue PackageNotFound
       false
     end

--- a/test/unit/test_packager.rb
+++ b/test/unit/test_packager.rb
@@ -33,6 +33,19 @@ class PackagerTest < Test::Unit::TestCase
     assert urls == ['/assets/jst_test_nested.jst']
   end
 
+  def test_package_includes
+    assert Jammit.packager.includes?(:css_test, :css)
+    assert Jammit.packager.includes?("css_test_nested", "css")
+    assert Jammit.packager.includes?(:js_test, :js)
+    assert Jammit.packager.includes?("js_test_nested", "js")
+    assert Jammit.packager.includes?(:jst_test, :js)
+    assert Jammit.packager.includes?("jst_test_nested", "js")
+
+    assert !Jammit.packager.includes?(:not_included_file, :js)
+    assert !Jammit.packager.includes?(:test1, :css)
+    assert !Jammit.packager.includes?(:"nested/nested1", :js)
+  end
+
   def test_packaging_stylesheets
     css = Jammit.packager.pack_stylesheets(:css_test)
     assert css == File.read('test/fixtures/jammed/css_test.css')
@@ -129,5 +142,4 @@ class PackagerTest < Test::Unit::TestCase
     assert File.read('test/public/assets/js_test.js') == File.read('test/fixtures/jammed/js_test_package_names.js')
     FileUtils.rm_rf("test/public/assets")
   end
-
 end


### PR DESCRIPTION
This allows us to detect the existence of a packaged asset at runtime, and gives us the ability to determine whether to call the Jammit stylesheet/javascript helper or the default Rails tag helpers.
