### PR TITLE
Updating depended-on version of cssmin to 1.0.3

### DIFF
--- a/jammit.gemspec
+++ b/jammit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
                          '--main'     << 'README' <<
                          '--all'
 
-  s.add_dependency 'cssmin', ['>= 1.0.2']
+  s.add_dependency 'cssmin', ['>= 1.0.3']
   s.add_dependency 'jsmin',  ['>= 1.0.1']
 
   s.files = Dir['lib/**/*', 'bin/*', 'rails/*', 'jammit.gemspec', 'LICENSE', 'README']


### PR DESCRIPTION
Jammit currently depends on cssmin v 1.0.2, which has a bug with handling media queries (e.g. https://github.com/rgrove/cssmin/issues/3). See related issue #117

Version 1.0.3 addresses this issue.
