### PR TITLE
upgrade yui-compressor gem to v0.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
   gem "rails", "2.3.14"
   gem "cssmin", "1.0.3"
   gem "jsmin", "1.0.1"
-  gem "yui-compressor", "0.9.6"
+  gem "yui-compressor", "0.11.0"
   gem "closure-compiler", "1.1.6"
   gem "uglifier", "1.3.0"
   gem "sass", "3.2.7"


### PR DESCRIPTION
I've made a few important changes to yui-compressor. I know its fallen out of favor with the community, but some of us do still use it. The jammit test suite seems to run just as well after the upgrade, but I'd appreciate any other testing you might want to do.
