### PR TITLE
Fix implicit string conversion of Pathname

### DIFF
--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -10,7 +10,7 @@ module Jammit
 
   ASSET_ROOT                    = File.expand_path((defined?(Rails) && Rails.root.to_s.length > 0) ? Rails.root : ENV['RAILS_ROOT'] || ".") unless defined?(ASSET_ROOT)
 
-  DEFAULT_PUBLIC_ROOT           = (defined?(Rails) && Rails.public_path.to_s.length > 0) ? Rails.public_path : File.join(ASSET_ROOT, 'public') unless defined?(PUBLIC_ROOT)
+  DEFAULT_PUBLIC_ROOT           = (defined?(Rails) && Rails.public_path.to_s.length > 0) ? Rails.public_path.to_s : File.join(ASSET_ROOT, 'public') unless defined?(PUBLIC_ROOT)
 
   DEFAULT_CONFIG_PATH           = File.join(ASSET_ROOT, 'config', 'assets.yml')
 


### PR DESCRIPTION
In Rails 3, `Rails.public_path` returns a String, but in Rails 4 it returns a Pathname. This breaks on the implicit conversion to String here: https://github.com/documentcloud/jammit/blob/master/lib/jammit/packager.rb#L113

If we explicitly instantiate DEFAULT_PUBLIC_ROOT as a String instead of a Pathname (as would happen in Rails 3 and earlier), the problem is solved.
