### PR TITLE
Replace uglifier with terser

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -96,8 +96,8 @@ module Jammit
         hash = Digest::MD5.hexdigest(js)
 
         sourcemap_opts = {
-          filename: "#{pack_name}.js",
-          url: "#{pack_name}.js.map?#{hash}"
+          output_filename: "#{pack_name}.js",
+          map_url: "#{pack_name}.js.map?#{hash}"
         }
 
         # Single-file bundles may require an input sourcemap too

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -30,7 +30,7 @@ module Jammit
     MAX_IMAGE_SIZE  = 32700
 
     # CSS asset-embedding regexes for URL rewriting.
-    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.[a-z]+)(\?\d*)?(?<anchor>#\w+)?['"]?\)/
+    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.\w+)(\?\d*)?(?<anchor>#.+)?['"]?\)/
     EMBEDDABLE      = /[\A\/]embed\//
     EMBED_REPLACER  = /url\(__EMBED__(.+?)(\?\d+)?\)/
 

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -30,7 +30,7 @@ module Jammit
     MAX_IMAGE_SIZE  = 32700
 
     # CSS asset-embedding regexes for URL rewriting.
-    EMBED_DETECTOR  = /url\(['"]?([^\s)]+\.[a-z]+)(\?\d+)?['"]?\)/
+    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.[a-z]+)(\?\d+)?(?<anchor>#\w+)?['"]?\)/
     EMBEDDABLE      = /[\A\/]embed\//
     EMBED_REPLACER  = /url\(__EMBED__(.+?)(\?\d+)?\)/
 
@@ -192,9 +192,10 @@ module Jammit
       stylesheets = [paths].flatten.map do |css_path|
         contents = read_binary_file(css_path)
         contents.gsub(EMBED_DETECTOR) do |url|
-          ipath, cpath = Pathname.new($1), Pathname.new(File.expand_path(css_path))
-          is_url = URI.parse($1).absolute?
-          is_url ? url : "url(#{construct_asset_path(ipath, cpath, variant)})"
+          path, anchor = url.match(EMBED_DETECTOR).values_at(:path, :anchor)
+          ipath, cpath = Pathname.new(path), Pathname.new(File.expand_path(css_path))
+          is_url = URI.parse(path).absolute?
+          is_url ? url : "url(#{construct_asset_path(ipath, cpath, variant)}#{anchor})"
         end
       end
       stylesheets.join("\n")

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -96,7 +96,7 @@ module Jammit
         result = context.call("UglifyJS.minify", files, {
           sourceMap: {
             filename: "#{pack_name}.js",
-            url: "#{pack_name}.js.map"
+            url: "#{pack_name}.js.map?#{Time.now.to_i}"
           }
         })
 

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -93,9 +93,11 @@ module Jammit
           files[relative_path] = read_binary_file(path)
         end
 
+        hash = Digest::MD5.hexdigest(files.values.inject(:+))
+
         sourcemap_opts = {
           filename: "#{pack_name}.js",
-          url: "#{pack_name}.js.map?#{Time.now.to_i}"
+          url: "#{pack_name}.js.map?#{hash}"
         }
 
         # Single-file bundles may require an input sourcemap too

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -30,7 +30,7 @@ module Jammit
     MAX_IMAGE_SIZE  = 32700
 
     # CSS asset-embedding regexes for URL rewriting.
-    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.\w+)(\?\d*)?(?<anchor>#.+)?['"]?\)/
+    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.\w+)(\?\d*)?(?<anchor>#[^'"]+)?['"]?\)/
     EMBEDDABLE      = /[\A\/]embed\//
     EMBED_REPLACER  = /url\(__EMBED__(.+?)(\?\d+)?\)/
 

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -30,7 +30,7 @@ module Jammit
     MAX_IMAGE_SIZE  = 32700
 
     # CSS asset-embedding regexes for URL rewriting.
-    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.[a-z]+)(\?\d+)?(?<anchor>#\w+)?['"]?\)/
+    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.[a-z]+)(\?\d*)?(?<anchor>#\w+)?['"]?\)/
     EMBEDDABLE      = /[\A\/]embed\//
     EMBED_REPLACER  = /url\(__EMBED__(.+?)(\?\d+)?\)/
 

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -260,7 +260,7 @@ module Jammit
     def rails_asset_id(path)
       asset_id = ENV["RAILS_ASSET_ID"]
       return asset_id if asset_id
-      File.exists?(path) ? File.mtime(path).to_i.to_s : ''
+      File.exists?(path) ? Digest::MD5.hexdigest(File.read(path)) : ''
     end
 
     # An asset is valid for embedding if it exists, is less than 32K, and is

--- a/lib/jammit/controller.rb
+++ b/lib/jammit/controller.rb
@@ -1,5 +1,5 @@
-require 'rails'
-require 'action_controller'
+autoload :Rails, 'rails'
+autoload :ActionController, 'action_controller'
 
 module Jammit
 

--- a/lib/jammit/helper.rb
+++ b/lib/jammit/helper.rb
@@ -26,11 +26,10 @@ module Jammit
     # except in development, where it references the individual scripts.
     def include_javascripts(*packages)
       options = packages.extract_options!
-      options.merge!(:extname=>false)
       html_safe packages.map {|pack|
         should_package? ? Jammit.asset_url(pack, :js) : Jammit.packager.individual_urls(pack.to_sym, :js)
       }.flatten.map {|pack|
-        "<script src=\"#{pack}\"></script>"
+        javascript_include_tag(pack, options)
       }.join("\n")
     end
 


### PR DESCRIPTION
This replaces Uglifier with the more modern Terser for minifying javascript, since Uglifier is only able to handle ES5 javascript and chokes on any modern syntax. Our plan to remove support for IE11 involves no longer transpiling our modern javascript down to ES5 syntax, so we need a corresponding minifier that's capable of understanding modern javascript. Terser also handles older javascript syntax just fine too, so this shouldn't yield any difference when minifying our older javascript code that's still written as ES5.